### PR TITLE
Add rate limiter (solves #6)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,22 @@
 const express = require('express');
+const { rateLimit } = require("express-rate-limit");
 const app = express();
 const port = process.env.PORT || 3000;
 const cors = require('cors')
 const ValidationFunctions = require('./validationFunctions')
+
+/**
+ * Global rate limiter middleware
+ * limits the number of request sent to our application
+ * each IP can make up to 1000 requests per `windowsMs` (1 minute)
+ */
+const limiter = rateLimit({
+  windowMs: 1 * 60 * 1000, // 1 minute
+  limit: 1000, 
+  standardHeaders: true, 
+  legacyHeaders: false, 
+});
+app.use(limiter)
 
 const requiredParameterResponse = 'Input string required as a parameter.'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.21.2",
+        "express-rate-limit": "^7.5.0",
         "install": "^0.13.0",
         "npm": "^11.1.0",
         "pug": "^3.0.3"
@@ -492,6 +493,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/fill-range": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.21.2",
+    "express-rate-limit": "^7.5.0",
     "install": "^0.13.0",
     "npm": "^11.1.0",
     "pug": "^3.0.3"


### PR DESCRIPTION
**Added express-rate-limit and set api requests to 1000/min.
Each Ip can send only 1000 requests per minute and after that express server will throw 429 error (Too many requests)**


![ss2](https://github.com/user-attachments/assets/315bc47d-0b24-4183-98fa-f15abd8adf7a)

**Each request sent has some additional headers for the rate limiter info.**

![ss1](https://github.com/user-attachments/assets/337fca4c-6f1f-49a8-8fa3-dde1860fd79e)
