### PR TITLE
Add search bar to swagger documentation #95

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "express-rate-limit": "^7.5.0",
         "install": "^0.13.0",
         "npm": "^11.1.0",
-        "pug": "^3.0.3"
+        "pug": "^3.0.3",
+        "swagger-ui-express": "^5.0.1"
       },
       "devDependencies": {
         "jest": "^29.7.0",
@@ -2203,6 +2204,21 @@
       },
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/express-jsdoc-swagger/node_modules/swagger-ui-express": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.6.3.tgz",
+      "integrity": "sha512-CDje4PndhTD2HkgyKH3pab+LKspDeB/NhPN2OF1j+piYIamQqBYwAXWESOT1Yju2xFg51bRW9sUng2WxDjzArw==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=4.11.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/express-rate-limit": {
@@ -7210,12 +7226,12 @@
       }
     },
     "node_modules/swagger-ui-express": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.6.3.tgz",
-      "integrity": "sha512-CDje4PndhTD2HkgyKH3pab+LKspDeB/NhPN2OF1j+piYIamQqBYwAXWESOT1Yju2xFg51bRW9sUng2WxDjzArw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
       "license": "MIT",
       "dependencies": {
-        "swagger-ui-dist": ">=4.11.0"
+        "swagger-ui-dist": ">=5.0.0"
       },
       "engines": {
         "node": ">= v0.10.32"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "express-rate-limit": "^7.5.0",
     "install": "^0.13.0",
     "npm": "^11.1.0",
-    "pug": "^3.0.3"
+    "pug": "^3.0.3",
+    "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/server.js
+++ b/server.js
@@ -157,7 +157,7 @@ app.use((err, req, res, next) => {
  * Contains request
  * @typedef {object} ContainsRequest
  * @property {string} inputString.required - Input string
- * @property {string} containsString.required - String contained
+  * @property {string} stringContained.required - String contained
  * @property {boolean} caseSensitive.required - Case sensitivity
  */
 
@@ -423,7 +423,7 @@ app.post('/api/trim', (req, res) => {
  * @example request - test
  * {
  *   "inputString": "   Hello World!   ",
- *   "containsString": "World",
+ *   "stringContained": "World",
  *   "caseSensitive": true
  * }
  * @example response - 200 - example payload
@@ -437,22 +437,22 @@ app.post('/api/trim', (req, res) => {
  */
 app.post('/api/contains', (req, res) => {
   const inputString = req.body.inputString;
-  const containsString = req.body.containsString; // <-- cambia aquí
+  const stringContained = req.body.stringContained;
   const caseSensitive = req.body.caseSensitive;
 
   if (!inputString) {
     return res.status(400).json({ error: requiredParameterResponse });
   }
 
-  if (!containsString) { // <-- cambia aquí
-    return res.status(400).json({ error: 'containsString is a required parameter' })
+  if (!stringContained) {
+    return res.status(400).json({ error: 'stringContained is a required parameter' })
   }
 
   if (caseSensitive === undefined) {
     return res.status(400).json({ error: 'caseSensitive is a required parameter' })
   }
 
-  const result = ValidationFunctions.contains(inputString, containsString, caseSensitive); // <-- cambia aquí
+  const result = ValidationFunctions.contains(inputString, stringContained, caseSensitive); // <-- cambia aquí
   res.json({ result });
 });
 

--- a/server.js
+++ b/server.js
@@ -452,7 +452,7 @@ app.post('/api/contains', (req, res) => {
     return res.status(400).json({ error: 'caseSensitive is a required parameter' })
   }
 
-  const result = ValidationFunctions.contains(inputString, stringContained, caseSensitive); // <-- cambia aquí
+  const result = ValidationFunctions.contains(inputString, stringContained, caseSensitive);
   res.json({ result });
 });
 

--- a/server.js
+++ b/server.js
@@ -12,6 +12,7 @@ const { handleAxiosError } = require("./utils/axios");
 const ValidationFunctions = require('./validationFunctions');
 const { urlUtils } = require("./utils/urlUtils");
 const expressJSDocSwagger = require('express-jsdoc-swagger');
+const swaggerUi = require('swagger-ui-express')
 const fetchAiGeneratedContent = require('./runGeminiPrompt');
 
 // Constants and Error Messages
@@ -26,7 +27,7 @@ const SIZE_LIMIT_ERROR = 'Input exceeds maximum size of 10MB';
  * each IP can make up to 1000 requests per `windowsMs` (1 minute)
  */
 const limiter = rateLimit({
-  windowMs: 1 * 60 * 1000, // 1 minute
+  windowMs: 1 * 60 * 1000,
   limit: 1000,
   standardHeaders: true,
   legacyHeaders: false,
@@ -55,9 +56,9 @@ const options = {
   // URL where SwaggerUI will be rendered
   swaggerUIPath: '/api-docs',
   // Expose OpenAPI UI
-  exposeSwaggerUI: true,
+  exposeSwaggerUI: false,
   // Expose Open API JSON Docs documentation in `apiDocsPath` path.
-  exposeApiDocs: false,
+  exposeApiDocs: true,
   // Open API JSON Docs endpoint.
   apiDocsPath: '/v3/api-docs',
   // Set non-required fields as nullable by default
@@ -65,13 +66,25 @@ const options = {
   // You can customize your UI options.
   // you can extend swagger-ui-express config. You can checkout an example of this
   // in the `example/configuration/swaggerOptions.js`
-  swaggerUiOptions: {},
+  swaggerUiOptions: {
+    filter: true
+  },
   // multiple option in case you want more that one instance
   multiple: true,
 };
 
+
 expressJSDocSwagger(app)(options);
 
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(undefined,
+  {
+    swaggerOptions: {
+      url: '/v3/api-docs',
+      filter: true,
+    },
+    ...options.swaggerUiOptions
+  }
+));
 
 app.use(limiter)
 
@@ -144,7 +157,7 @@ app.use((err, req, res, next) => {
  * Contains request
  * @typedef {object} ContainsRequest
  * @property {string} inputString.required - Input string
- * @property {string} stringContained.required - String contained
+ * @property {string} containsString.required - String contained
  * @property {boolean} caseSensitive.required - Case sensitivity
  */
 
@@ -197,6 +210,7 @@ app.use((err, req, res, next) => {
  * @param {GeminiValidationRequest} request.body.required
  * @return {GeminiResponse} 200 - Success response
  * @return {BadRequestResponse} 400 - Bad request response
+ * @tags IsEmailAddress
  * @example request - test
  * {
  *   "inputString": "test@gmail.com",
@@ -423,24 +437,22 @@ app.post('/api/trim', (req, res) => {
  */
 app.post('/api/contains', (req, res) => {
   const inputString = req.body.inputString;
-  const stringContained = req.body.stringContained
-  const caseSensitive = req.body.caseSensitive
+  const containsString = req.body.containsString; // <-- cambia aquí
+  const caseSensitive = req.body.caseSensitive;
 
   if (!inputString) {
     return res.status(400).json({ error: requiredParameterResponse });
   }
 
-  if (!stringContained) {
-    return res.status(400).json({ error: 'stringContained is a required parameter' })
+  if (!containsString) { // <-- cambia aquí
+    return res.status(400).json({ error: 'containsString is a required parameter' })
   }
 
-  // only throw an error if caseSensitive is not passed, which means it's undefiend. 
-  // The ! operation won't work because when a boolean is passed, it will flip it, instead of checking if the value exists
   if (caseSensitive === undefined) {
     return res.status(400).json({ error: 'caseSensitive is a required parameter' })
   }
 
-  const result = ValidationFunctions.contains(inputString, stringContained, caseSensitive)
+  const result = ValidationFunctions.contains(inputString, containsString, caseSensitive); // <-- cambia aquí
   res.json({ result });
 });
 


### PR DESCRIPTION
# Why Use swagger-ui-express Alongside

https://github.com/ReadableRegex/readableRegex/issues/95

Why Add swagger-ui-express?
While provides a built-in Swagger UI, it is limited in terms of customization and features compared to the standalone package. Some of the main reasons to use swagger-ui-express in addition are:

Advanced UI Options: swagger-ui-express exposes more configuration options, such as enabling endpoint filtering, customizing layout, and other UI features.
Latest Features: The built-in UI in  may not always be up to date with the latest Swagger UI features and bug fixes.
Separation of Concerns: Using swagger-ui-express allows you to separate the OpenAPI spec generation (handled by from the UI rendering (handled by swagger-ui-express), giving you more flexibility.
Filtering Limitation
A key limitation to be aware of is that the filtering feature in Swagger UI only works by tag when using the standard integration.
Even if you enable the filter option, the filter bar in Swagger UI will only filter endpoints by their assigned tags.
It does not filter by summary or path (endpoint URL or description) in this setup.

<img width="1919" height="912" alt="image" src="https://github.com/user-attachments/assets/a2746a33-15e7-45ea-93e8-3f864f6ac0a7" />

<img width="1919" height="905" alt="image" src="https://github.com/user-attachments/assets/ed80d8c9-8cd3-4e43-999b-194979b3c296" />

<img width="1919" height="908" alt="image" src="https://github.com/user-attachments/assets/02b2fac1-93f1-4e9d-9e68-114ab80b8216" />

